### PR TITLE
Fix typo in Piper TTS error handling

### DIFF
--- a/src/pipecat/services/piper/tts.py
+++ b/src/pipecat/services/piper/tts.py
@@ -72,12 +72,12 @@ class PiperTTSService(TTSService):
 
             async with self._session.post(self._base_url, data=text, headers=headers) as response:
                 if response.status != 200:
-                    eror = await response.text()
+                    error = await response.text()
                     logger.error(
-                        f"{self} error getting audio (status: {response.status}, error: {eror})"
+                        f"{self} error getting audio (status: {response.status}, error: {error})"
                     )
                     yield ErrorFrame(
-                        f"Error getting audio (status: {response.status}, error: {eror})"
+                        f"Error getting audio (status: {response.status}, error: {error})"
                     )
                     return
 


### PR DESCRIPTION
## Summary
- fix variable name in `PiperTTSService.run_tts`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6841174b5970832892b3fede3570a1c8